### PR TITLE
New function: Add automatically source/output while holding Shift key

### DIFF
--- a/Foreman/ProductionGraphView/ProductionGraphViewer.cs
+++ b/Foreman/ProductionGraphView/ProductionGraphViewer.cs
@@ -312,6 +312,17 @@ namespace Foreman
 				Graph.UpdateNodeStates();
 				Invalidate();
 			}
+			else if ((Control.ModifierKeys & Keys.Shift) == Keys.Shift)
+			{
+				if (nNodeType == NewNodeType.Consumer)
+				{
+					ProcessNodeRequest(null, new RecipeRequestArgs(NodeType.Consumer, null));
+				}
+				else
+				{
+					ProcessNodeRequest(null, new RecipeRequestArgs(NodeType.Supplier, null));
+				}
+			}
 			else
 			{
 				fRange tempRange = new fRange(0, 0, true);


### PR DESCRIPTION
Holding Shift key will create automatically source/output node - similar to holding CTRL and autocreating pass-through